### PR TITLE
Cargo incorrectly warns that Payloads is unused in the init_postmaster macro #38

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@ pub use error::PostmasterError;
 macro_rules! init_postmaster {
 
     ($address_enum:ty, $payload_enum:ty, $timeout_us: expr) => {
+        // Fix incorrect cargo warning that payloads is unused
+        #[allow(unused_imports)]
+
         /// API module for the Postmaster
         /// This module contains all of the functions required to pass messages between Agents, facilitated by the Postmaster.
         ///


### PR DESCRIPTION
Cargo has been incorrectly raising a warning stating that `Payloads` in the `init_postmaster!(Addresses, Payloads)` is unused. 

This happens for all of the post-haste examples.

Note that I am using these versions:
- cargo 1.97.0-nightly (eb9b60f1f 2026-04-24)
- rustc 1.97.0-nightly (c935696dd 2026-04-29)

This can be fixed with a single `#[allow(unused_imports)]`

See the issue I raised:
#38 