### PR TITLE
Remove implicit copy requirement from address type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-haste"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 
 [dependencies]

--- a/examples/tinyc6/Cargo.lock
+++ b/examples/tinyc6/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "post-haste"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "const_env",
  "embassy-executor",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,9 +381,10 @@ macro_rules! init_postmaster {
                     address: Addresses,
                     mailbox: Mailbox,
                 ) -> Result<(), PostmasterError> {
+                    let address_index = address as usize;
                     let mut senders = POSTMASTER.senders.lock().await;
-                    if senders[address as usize].is_none() {
-                        senders[address as usize].replace(mailbox);
+                    if senders[address_index as usize].is_none() {
+                        senders[address_index as usize].replace(mailbox);
                         Ok(())
                     } else {
                         return Err(PostmasterError::AddressAlreadyTaken);
@@ -478,7 +479,6 @@ macro_rules! init_postmaster {
                     timeout: Option<Duration>,
                 ) {
                     sleep(delay).await;
-                    let source = message.source;
                     match send_internal(destination, message, timeout).await {
                         Ok(_) => (),
                         Err(error) => (), // TODO: Can we find a way to convey back to the source that the sending failed?


### PR DESCRIPTION
If the user hadn't derived Copy for the Address type, `init_postmaster()` would generate errors.